### PR TITLE
Running limonero with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:2.7-onbuild
+MAINTAINER Guilherme Maluf <guimalufb@gmail.com>
+
+EXPOSE 5000
+CMD [ "python", "./limonero/app_api.py", "-c", "limonero.json" ]

--- a/README.md
+++ b/README.md
@@ -33,3 +33,17 @@ Edit `limonero.json` according to your database config
 ```
 python limonero/app_api.py -c limonero.json
 ```
+
+#### Using docker
+Build the container
+```
+docker build -t bigsea/limonero .
+```
+
+Repeat [config](#config) stop and run using config file
+```
+docker run \
+  -v $PWD/limonero.json:/usr/src/app/limonero.json \
+  -p 5000:5000 \
+  bigsea/limonero
+```


### PR DESCRIPTION
Includes Dockerfile based on python:2.7 container which install
requimentes.txt and run app_api based on README instructions
