### PR TITLE
Change how Java dependencies are downloaded

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,27 +7,23 @@ FROM openjdk:8-jre-alpine
 LABEL maintainer="Vinicius Dias <viniciusvdias@dcc.ufmg.br>, Guilherme Maluf \
 <guimalufb@gmail.com>, Gabriel Barbutti <gabrielbarbutti@gmail.com>"
 
-ARG SPARK_VERSION=2.3.1
-ARG HADOOP_VERSION=2.7
-ARG SPARK_HADOOP_PKG=spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}
-ARG SPARK_HADOOP_URL=http://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/${SPARK_HADOOP_PKG}.tgz
-
 ENV LIMONERO_HOME=/usr/local/limonero \
-    SPARK_HOME=/usr/local/spark
-ENV LIMONERO_CONFIG=$LIMONERO_HOME/conf/limonero-config.yaml \
-    PYTHONPATH=$PYTHONPATH:$JUICER_HOME:$SPARK_HOME/python
-
-RUN wget ${SPARK_HADOOP_URL} -O- | tar -xz -C /usr/local/ \
-    && mv /usr/local/$SPARK_HADOOP_PKG $SPARK_HOME
+    LIMONERO_CONFIG=${LIMONERO_HOME}/conf/limonero-config.yaml \
+    PYTHONPATH=${PYTHONPATH}:${JUICER_HOME}
 
 COPY --from=pip_build /usr/local /usr/local
 
-# Java dependencies
-RUN mkdir -p $LIMONERO_HOME/jars \
-   && cat java_libs.dep | xargs --max-args 1  wget --quiet --directory-prefix $LIMONERO_HOME/jars
-ENV CLASSPATH $LIMONERO_HOME/jars/*.jar
-
 WORKDIR $LIMONERO_HOME
-COPY . $LIMONERO_HOME
 
+# Java dependencies
+ARG IVY_VERSION=2.3.0
+ARG IVY_PKG=ivy-${IVY_VERSION}.jar
+ARG IVY_URL=http://search.maven.org/remotecontent?filepath=org/apache/ivy/ivy/${IVY_VERSION}/${IVY_PKG}
+
+COPY ivy.xml ./
+RUN wget --quiet --directory-prefix /tmp $IVY_URL \
+  && java -jar /tmp/${IVY_PKG} -retrieve "${LIMONERO_HOME}/jars/[artifact]-[revision](-[classifier]).[ext]" \
+  && rm /tmp/${IVY_PKG}
+
+COPY . $LIMONERO_HOME
 CMD ["/usr/local/limonero/sbin/limonero-daemon.sh", "docker"]

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,0 +1,9 @@
+<ivy-module version="1.0">
+    <info organisation="br.ufmg.dcc.speed" module="lemonade-limonero"/>
+    <dependencies>
+        <dependency org="org.apache.hadoop" name="hadoop-client" rev="2.9.1">
+            <exclude org="*" ext="*" type="source"/>
+            <exclude org="*" ext="*" type="javadoc"/>
+        </dependency>
+    </dependencies>
+</ivy-module>

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,6 @@ pyaml==17.12.1
 PyMySQL==0.8.0
 pyparsing==2.2.0
 pyshp==1.2.12
-pyspark==2.3.0
 python-dateutil==2.6.1
 python-editor==1.0.3
 pytz==2017.3


### PR DESCRIPTION
I changed how dependencies are download. Instead of downloading all Spark, docker uses Ivy to download HDFS client. All dependencies are managed by Ivy, so we don't need to worry. Please, test if it is working with Compose and if it's possible to optimize the build process.